### PR TITLE
Bean Scope 지원 추가 (@Scope, @ScopeType: SINGLETON/PROTOTYPE)

### DIFF
--- a/docs/application-context-sequence.md
+++ b/docs/application-context-sequence.md
@@ -1,3 +1,86 @@
+## ApplicationContext Full Sequence Diagram
+- 스코프 추가, 지연 초기화, 다형성 조회 등을 포함한 시퀀스 다이어그램 
+### 포인트 요약
+- 싱글톤: 초기화 때(또는 최초 요청 시) 한 번 생성 → singletons 캐시에 저장 후 재사용.
+- 프로토타입: 요청/주입 시마다 새로 생성, 캐시에 저장하지 않음.
+- 의존성 주입도 스코프 규칙을 그대로 따름(싱글톤 주입=캐시, 프로토타입 주입=새 생성).
+
+```mermaid
+sequenceDiagram
+    participant User as User Code
+    participant AppCtx as ApplicationContext
+    participant Ref as Reflections
+    participant Def as beanDefinitions(클래스→스코프)
+    participant Single as singletons(Map)
+    participant Comp as @Component Classes
+    participant Ctor as Constructor Reflection
+
+    Note over AppCtx: 컨텍스트 초기화 시점
+    User->>AppCtx: ApplicationContext.of("myspring.core")
+    AppCtx->>Ref: scan for @Component classes
+    Ref-->>AppCtx: return [C1, C2, ...]
+    AppCtx->>Def: 등록: Ck -> ScopeType (기본 SINGLETON)
+    loop Eager init for SINGLETON only
+        AppCtx->>AppCtx: getOrCreateSingleton(Ck)
+        alt 캐시에 있음
+            AppCtx->>Single: get(Ck)
+            Single-->>AppCtx: instance
+        else 캐시에 없음
+            AppCtx->>Ctor: selectConstructor(Ck)
+            AppCtx->>AppCtx: resolveDependency(params)
+            AppCtx->>Ctor: newInstance(args)
+            AppCtx->>Single: put(Ck, instance)
+        end
+    end
+
+    Note over AppCtx: 런타임 조회 시점
+    User->>AppCtx: getBean(T)
+    alt 정확 매칭: Def.contains(T)
+        AppCtx->>Def: scope = Def[T]
+        alt scope == SINGLETON
+            AppCtx->>Single: getOrCreateSingleton(T)
+            Single-->>AppCtx: instance
+        else scope == PROTOTYPE
+            AppCtx->>AppCtx: createNewInstanceGraph(T)
+            AppCtx->>Ctor: selectConstructor(T)
+            AppCtx->>AppCtx: resolveDependency(params)
+            AppCtx->>Ctor: newInstance(args)
+            AppCtx-->>User: prototype instance (no cache)
+        end
+    else 다형성 매칭 (인터페이스/상위타입)
+        AppCtx->>Comp: filter assignable to T
+        Comp-->>AppCtx: candidates
+        alt 후보 1개
+            AppCtx->>Def: scope of candidate
+            opt SINGLETON
+                AppCtx->>Single: getOrCreateSingleton(candidate)
+                Single-->>AppCtx: instance
+            end
+            opt PROTOTYPE
+                AppCtx->>AppCtx: createNewInstanceGraph(candidate)
+                AppCtx-->>User: prototype instance
+            end
+        else 0 or N>1
+            AppCtx-->>User: throw IllegalArgumentException
+        end
+    end
+    AppCtx-->>User: return bean
+
+    Note over AppCtx: resolveDependency(depType)
+    AppCtx->>Comp: find component assignable to depType
+    Comp-->>AppCtx: targetClass
+    AppCtx->>Def: scope = Def[targetClass]
+    alt dep SINGLETON
+        AppCtx->>Single: getOrCreateSingleton(targetClass)
+        Single-->>AppCtx: dep instance
+    else dep PROTOTYPE
+        AppCtx->>AppCtx: createNewInstanceGraph(targetClass)
+        AppCtx-->>AppCtx: new dep instance
+    end
+
+```
+
+### ApplicationContext Sequence Diagram
 ```mermaid
 sequenceDiagram
 participant User as User Code

--- a/src/main/java/myspring/core/annotation/Scope.java
+++ b/src/main/java/myspring/core/annotation/Scope.java
@@ -1,0 +1,14 @@
+package myspring.core.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Scope {
+    ScopeType value() default ScopeType.SINGLETON; // 디폴트는 SINGLETON
+}

--- a/src/main/java/myspring/core/annotation/ScopeType.java
+++ b/src/main/java/myspring/core/annotation/ScopeType.java
@@ -1,0 +1,6 @@
+package myspring.core.annotation;
+
+public enum ScopeType {
+    SINGLETON, // 없으면 생성, 있으면 재사용
+    PROTOTYPE // 매번 새로 생성
+}

--- a/src/test/java/myspring/core/ScopeTest.java
+++ b/src/test/java/myspring/core/ScopeTest.java
@@ -1,0 +1,38 @@
+// src/test/java/myspring/core/ScopeTest.java
+package myspring.core;
+
+import myspring.core.annotation.Component;
+import myspring.core.annotation.Scope;
+import myspring.core.annotation.ScopeType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ScopeTest {
+
+    @Component
+    static class SingletonBean {}
+
+    @Component
+    @Scope(ScopeType.PROTOTYPE)
+    static class PrototypeBean {}
+
+    @Test
+    @DisplayName("기본 스코프는 SINGLETON: 같은 인스턴스를 반환한다")
+    void default_is_singleton() {
+        ApplicationContext ctx = ApplicationContext.of("myspring.core");
+        SingletonBean a = ctx.getBean(SingletonBean.class);
+        SingletonBean b = ctx.getBean(SingletonBean.class);
+        assertSame(a, b);
+    }
+
+    @Test
+    @DisplayName("PROTOTYPE 스코프는 매번 새로운 인스턴스를 반환한다")
+    void prototype_returns_new_instance_every_time() {
+        ApplicationContext ctx = ApplicationContext.of("myspring.core");
+        PrototypeBean a = ctx.getBean(PrototypeBean.class);
+        PrototypeBean b = ctx.getBean(PrototypeBean.class);
+        assertNotSame(a, b);
+    }
+}


### PR DESCRIPTION
[#5]
## 설명
@Scope 애노테이션과 ScopeType(SINGLETON, PROTOTYPE) 추가
ApplicationContext에서 스코프 메타정보를 등록하고 관리하도록 수정
- SINGLETON → 캐시에 한 번 생성 후 재사용
- PROTOTYPE → 요청 시마다 새 인스턴스 생성

## 변경 사항
- @Scope, ScopeType enum 정의
- ApplicationContext 리팩토링
- singletons 맵 도입 (싱글톤 캐시)
- beanDefinitions 맵 도입 (클래스 → 스코프)
- getBean() 호출 시 스코프에 따라 반환 로직 분기
- 단위 테스트 (ScopeTest) 추가

## 효과

컨테이너가 단일 인스턴스뿐만 아니라, 매번 새 객체를 반환하는 빈까지 지원
스프링의 기본 개념인 Scope(SINGLETON/PROTOTYPE)를 학습/구현 완료