### PR TITLE
[#11] Bean 라이프사이클 지원 추가

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -8,6 +8,9 @@ reviews:
   auto_review:
     enabled: true
     auto_incremental_review: true
+  poem: false
+  summary: true
+  severity: high
 
 languages:
   - java

--- a/docs/application-context-added-lifecycle.md
+++ b/docs/application-context-added-lifecycle.md
@@ -1,0 +1,47 @@
+```mermaid
+sequenceDiagram
+    participant Main as main()
+    participant AppCtx as ApplicationContext
+    participant Ref as Reflections
+    participant Def as beanDefinitions
+    participant Single as singletons
+    participant LP as LifecycleProcessor
+    participant Ctor as Constructor Reflection
+    participant Demo as DemoService(@Component)
+
+    Note over Main: try (ApplicationContext.of("myspring")) { ... }
+    Main->>AppCtx: of("myspring")
+    AppCtx->>Ref: scan for @Component
+    Ref-->>AppCtx: [DemoService, ...]
+    AppCtx->>Def: 등록: DemoService -> SINGLETON(기본)
+    loop eager init for SINGLETON
+        AppCtx->>Single: get(DemoService)?
+        alt not exists
+            AppCtx->>Ctor: selectConstructor(DemoService)
+            AppCtx->>AppCtx: resolveDependency(params)
+            AppCtx->>Ctor: newInstance(args)
+            Ctor-->>AppCtx: instance(Demo)
+            AppCtx->>LP: invokePostConstruct(Demo)
+            LP-->>AppCtx: (ok)
+            AppCtx->>Single: put(DemoService, Demo)
+        else exists
+            Single-->>AppCtx: Demo
+        end
+    end
+
+    Note over Main,AppCtx: 런타임 사용
+    Main->>AppCtx: getBean(DemoService.class)
+    AppCtx->>Single: getOrCreateSingleton(DemoService)
+    Single-->>AppCtx: Demo
+    AppCtx-->>Main: Demo
+    Main->>Demo: doWork()
+
+    Note over Main: try-with-resources 종료 시점
+    Main->>AppCtx: close()
+    AppCtx->>LP: invokePreDestroyAll(singletons.values)
+    LP->>Demo: @PreDestroy()
+    Demo-->>LP: (ok)
+    LP-->>AppCtx: done
+    AppCtx-->>Main: closed
+
+```

--- a/src/main/java/myspring/Main.java
+++ b/src/main/java/myspring/Main.java
@@ -1,7 +1,44 @@
 package myspring;
 
+import myspring.core.ApplicationContext;
+import myspring.core.annotation.Component;
+import myspring.core.annotation.PostConstruct;
+import myspring.core.annotation.PreDestroy;
+
 public class Main {
     public static void main(String[] args) {
-        System.out.println("Hello, World!");
+        try (ApplicationContext ctx = ApplicationContext.of("myspring")) {
+            DemoService demo = ctx.getBean(DemoService.class);
+            demo.doWork();
+        }
+        // 여기서 자동으로 @PreDestroy 메서드 실행됨
+    }
+
+    /*
+    * 실행결과
+    *
+        > Task :myspring.Main.main()
+        [DemoService] @PostConstruct 실행!
+        [DemoService] 작업 중...
+        [DemoService] @PreDestroy 실행!
+    *
+    * */
+}
+
+
+@Component
+class DemoService {
+    @PostConstruct
+    public void init() {
+        System.out.println("[DemoService] @PostConstruct 실행!");
+    }
+
+    public void doWork() {
+        System.out.println("[DemoService] 작업 중...");
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        System.out.println("[DemoService] @PreDestroy 실행!");
     }
 }

--- a/src/main/java/myspring/core/LifecycleProcessor.java
+++ b/src/main/java/myspring/core/LifecycleProcessor.java
@@ -1,0 +1,40 @@
+package myspring.core;
+
+import myspring.core.annotation.PostConstruct;
+import myspring.core.annotation.PreDestroy;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+public class LifecycleProcessor {
+
+    /** 생성/주입 완료 직후 호출 (@PostConstruct 전부 실행) */
+    public void invokePostConstruct(Object bean) {
+        invokeAnnotated(bean, PostConstruct.class);
+    }
+
+    /** 컨텍스트 종료 시 호출 (@PreDestroy 전부 실행) */
+    public void invokePreDestroy(Object bean) {
+        invokeAnnotated(bean, PreDestroy.class);
+    }
+
+    /** 여러 빈에 대해 PreDestroy 실행 (싱글톤 캐시에 대해 사용) */
+    public void invokePreDestroyAll(Collection<?> beans) {
+        for (Object bean : beans) invokePreDestroy(bean);
+    }
+
+    private void invokeAnnotated(Object bean, Class<?> annoType) {
+        Class<?> clazz = bean.getClass();
+        for (Method m : clazz.getDeclaredMethods()) {
+            if (m.isAnnotationPresent((Class) annoType)) {
+                m.setAccessible(true);
+                try {
+                    m.invoke(bean);
+                } catch (Exception e) {
+                    throw new RuntimeException(
+                            "Lifecycle method failed: " + clazz.getName() + "#" + m.getName(), e);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/myspring/core/annotation/PostConstruct.java
+++ b/src/main/java/myspring/core/annotation/PostConstruct.java
@@ -1,0 +1,11 @@
+package myspring.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD) // 메서드에 붙일 수 있음
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PostConstruct {
+}

--- a/src/main/java/myspring/core/annotation/PreDestroy.java
+++ b/src/main/java/myspring/core/annotation/PreDestroy.java
@@ -1,0 +1,12 @@
+package myspring.core.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PreDestroy {
+}

--- a/src/test/java/myspring/core/LifecycleProcessorTest.java
+++ b/src/test/java/myspring/core/LifecycleProcessorTest.java
@@ -1,0 +1,50 @@
+package myspring.core;
+
+import myspring.core.annotation.Component;
+import myspring.core.annotation.PostConstruct;
+import myspring.core.annotation.PreDestroy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("LifecycleProcessor 테스트")
+class LifecycleProcessorTest {
+
+    static class Dummy {
+        boolean inited, destroyed;
+
+        @PostConstruct void init() { inited = true; }
+        @PreDestroy   void bye()  { destroyed = true; }
+    }
+
+    @Test
+    @DisplayName("@PostConstruct, @PreDestroy 호출")
+    void invoke_hooks() {
+        LifecycleProcessor lp = new LifecycleProcessor();
+        Dummy d = new Dummy();
+
+        lp.invokePostConstruct(d);
+        assertTrue(d.inited);
+
+        lp.invokePreDestroy(d);
+        assertTrue(d.destroyed);
+    }
+
+    @Component
+    static class WithPrivate {
+        boolean inited;
+
+        @PostConstruct
+        private void init() { inited = true; }
+    }
+
+    @Test
+    @DisplayName("private 메서드도 호출 가능")
+    void allows_non_public_methods() {
+        LifecycleProcessor lp = new LifecycleProcessor();
+        WithPrivate w = new WithPrivate();
+        lp.invokePostConstruct(w);
+        assertTrue(w.inited);
+    }
+}

--- a/src/test/java/myspring/core/ScopeTest.java
+++ b/src/test/java/myspring/core/ScopeTest.java
@@ -1,4 +1,3 @@
-// src/test/java/myspring/core/ScopeTest.java
 package myspring.core;
 
 import myspring.core.annotation.Component;


### PR DESCRIPTION
## 설명
- `@PostConstruct @PreDestroy` 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 컴포넌트 초기화/종료 어노테이션 지원: 생성 직후 초기화와 컨텍스트 종료 시 정리 로직이 자동 실행됩니다.
  - 애플리케이션 컨텍스트의 종료 지원 추가로 우아한 종료와 전체 싱글톤 정리가 가능해졌습니다.
  - 컨텍스트를 자동으로 닫는 사용 패턴(try-with-resources 등)을 통해 종료 처리가 간편해졌습니다.
- 테스트
  - 라이프사이클 훅 동작과 비공개 메서드 호출 지원을 검증하는 테스트 추가.
- 스타일
  - 사소한 주석/서식 정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->