### PR TITLE
[#13] @Configuration + @Bean 지원

### DIFF
--- a/src/main/java/myspring/config/AppConfig.java
+++ b/src/main/java/myspring/config/AppConfig.java
@@ -1,0 +1,32 @@
+package myspring.config;
+
+import myspring.core.annotation.Bean;
+import myspring.core.annotation.Configuration;
+import myspring.core.annotation.ScopeType;
+import myspring.sample.Repo;
+import myspring.sample.InMemoryRepo;
+import myspring.sample.Service;
+
+@Configuration
+public class AppConfig {
+
+    // 구현체를 코드로 고정하고 싶을 때
+    @Bean
+    Repo repo() {
+        System.out.println("AppConfig.repo() called");
+        return new InMemoryRepo();
+    }
+
+    // 파라미터 DI: Repo 빈을 주입받아 조립
+    @Bean
+    Service service(Repo repo) {
+        System.out.println("AppConfig.service() called");
+        return new Service(repo);
+    }
+
+    @Bean(scope = ScopeType.PROTOTYPE)
+    String uuid() {
+        System.out.println("AppConfig.uuid() called");
+        return java.util.UUID.randomUUID().toString();
+    }
+}

--- a/src/main/java/myspring/core/annotation/Bean.java
+++ b/src/main/java/myspring/core/annotation/Bean.java
@@ -1,0 +1,13 @@
+package myspring.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Bean {
+    String name() default "";
+    ScopeType scope() default ScopeType.SINGLETON;
+}

--- a/src/main/java/myspring/core/annotation/Configuration.java
+++ b/src/main/java/myspring/core/annotation/Configuration.java
@@ -1,0 +1,11 @@
+package myspring.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Component // 메타 애노테이션: 설정 클래스 자체도 컴포넌트 스캔 대상
+public @interface Configuration { }

--- a/src/main/java/myspring/sample/InMemoryRepo.java
+++ b/src/main/java/myspring/sample/InMemoryRepo.java
@@ -1,0 +1,10 @@
+package myspring.sample;
+
+import myspring.core.annotation.Component;
+
+@Component
+public class InMemoryRepo implements Repo{
+    public String find(String data) {
+        return data;
+    }
+}

--- a/src/main/java/myspring/sample/Repo.java
+++ b/src/main/java/myspring/sample/Repo.java
@@ -1,0 +1,6 @@
+package myspring.sample;
+
+public interface Repo {
+    String find(String data);
+}
+

--- a/src/main/java/myspring/sample/Service.java
+++ b/src/main/java/myspring/sample/Service.java
@@ -1,0 +1,16 @@
+package myspring.sample;
+
+import myspring.core.annotation.Component;
+
+@Component
+public class Service {
+
+    private final Repo repo;
+    public Service(Repo repo) {
+        this.repo = repo;
+    }
+    public String call(String str) {
+        System.out.println("Service.call() str = " + str);
+        return str + repo.find("data");
+    }
+}

--- a/src/test/java/myspring/core/AppConfigTest.java
+++ b/src/test/java/myspring/core/AppConfigTest.java
@@ -1,0 +1,30 @@
+package myspring.core;
+
+import myspring.sample.Service;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AppConfigTest {
+
+    @Test
+    @DisplayName("@Bean 메서드는 싱글톤 캐시에 등록되고 DI가 적용된다")
+    void bean_method_singleton_and_di() {
+        ApplicationContext ctx = ApplicationContext.of("myspring");
+        Service s1 = ctx.getBean(Service.class);
+        Service s2 = ctx.getBean(Service.class);
+
+        assertSame(s1, s2);
+        assertEquals("service component:data", s1.call("service component:"));
+    }
+
+    @Test
+    @DisplayName("@Bean(scope=PROTOTYPE)은 매번 새 인스턴스를 리턴한다")
+    void prototype_from_bean_method() {
+        ApplicationContext ctx = ApplicationContext.of("myspring");
+        String a = ctx.getBean(String.class);   // uuid()
+        String b = ctx.getBean(String.class);
+        assertNotSame(a, b);
+    }
+}


### PR DESCRIPTION
## 설명
- 이번 PR에서 변경된 주요 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 구성 클래스와 @Bean 메서드로 빈을 등록·관리할 수 있습니다.
  - 생성자 및 @Bean 메서드 파라미터를 통한 의존성 주입을 지원합니다.
  - 싱글톤 및 프로토타입 스코프를 선택해 사용할 수 있습니다.
  - @Bean 반환 타입에 따른 빈 생성 흐름이 통합되어 일관된 생명주기를 보장합니다.
- 샘플
  - 동작 확인용 저장소/서비스 샘플 컴포넌트가 포함되었습니다.
- 테스트
  - @Bean 동작(싱글톤/프로토타입, DI)을 검증하는 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->